### PR TITLE
added scrapping layer with tests

### DIFF
--- a/Channel.py
+++ b/Channel.py
@@ -1,56 +1,75 @@
 from utils import Keys, json_value_extract, YtElms, generate_video_url
 
 class Channel:
-    def __init__(self):
-        self.created_playlists_metadata = {} # we only regard the created playlists, other playlists jsons will not be passed to channel class for now at least
-        self.all_uploads_videos = {}
-    
-    def extract_all_playlists_from_a_playlists_category_json_response(self, playlists_category:dict)->bool:
-        '''Extracts all playlists in the a category of playlists in a channel, for example created playlists category or saved playlists category
-        Returns:
-            bool: True if we need to scroll more to get the rest of the playlists, otherwise returns False
-        '''
-        playlists = json_value_extract(playlists_category, YtElms.SINGLE_CHANNEL_PLAYLIST_CARD)
-        found_new_playlists = 0
-        for p in playlists:
-            title = self.find_title(p)
-            playlist_id = p[YtElms.PLAYLIST_ID] # this is the playlist id in the youtube json, don't use the Keys enum!
-            video_count = p['videoCountShortText']['simpleText']
-            video_count = int(video_count.replace(',','')) # remove comma if we have 4,999 or somthing
+	def __init__(self):
+		self.created_playlists_metadata = {} # we only regard the created playlists, other playlists jsons will not be passed to channel class for now at least
+		self.all_uploads_videos = {}
+	
+	def extract_all_playlists_from_a_playlists_category_json_response(self, playlists_category:dict)->bool:
+		'''Extracts all playlists in the a category of playlists in a channel, for example created playlists category or saved playlists category
+		Returns:
+			bool: True if we need to scroll more to get the rest of the playlists, otherwise returns False
+		'''
+		playlists = json_value_extract(playlists_category, YtElms.SINGLE_CHANNEL_PLAYLIST_CARD)
+		# found_new_playlists = 0
+		for p in playlists:
+			title = self.find_title(p)
+			playlist_id = p[YtElms.PLAYLIST_ID] # this is the playlist id in the youtube json, don't use the Keys enum!
+			video_count = p['videoCountShortText']['simpleText']
+			video_count = int(video_count.replace(',','')) # remove comma if we have 4,999 or somthing
 
-            if not self.does_key_exist(playlist_id):
-                self.created_playlists_metadata[playlist_id] = {
-                    Keys.PLAYLIST_NAME:title,
-                    Keys.PLAYLIST_GROSS_VIDEOS_NUMBER: video_count
-                }
-                found_new_playlists +=1
+			if not self.does_playlist_key_exist(playlist_id):
+				self.created_playlists_metadata[playlist_id] = {
+					Keys.PLAYLIST_NAME:title,
+					Keys.PLAYLIST_GROSS_VIDEOS_NUMBER: video_count
+				}
+				# found_new_playlists +=1
 
-        # print("number of playlists to add", found_new_playlists)
-        need_to_scroll = len(json_value_extract(playlists_category, YtElms.PLAYLIST_NEED_TO_SCROLL)) > 0
-        return need_to_scroll
-
-
-    def extract_videos_from_all_uploads_json_response(self, all_uploads_json:dict):
-        videos = json_value_extract(all_uploads_json, YtElms.ALL_UPLOADS_VIDEO_ITEM)
-        for video in videos:
-            video_id = video[YtElms.VIDEO_ID]
-            video_url = generate_video_url(video_id)
-            video_title = self.find_title(video)
-            self.all_uploads_videos[video_id] = {Keys.VIDEO_NAME: video_title, Keys.URL: video_url}
-
-        # the same YtElms key name is reused 
-        need_to_scroll = len(json_value_extract(all_uploads_json, YtElms.PLAYLIST_NEED_TO_SCROLL)) > 0 
-        return need_to_scroll
+		# print("number of playlists to add", found_new_playlists)
+		need_to_scroll = len(json_value_extract(playlists_category, YtElms.PLAYLIST_NEED_TO_SCROLL)) > 0
+		return need_to_scroll
 
 
-    def does_key_exist(self, key):
-        if key in self.created_playlists_metadata.keys():
-            return True
-        return False
+	def extract_videos_from_all_uploads_json_response(self, all_uploads_json:dict):
+		videos = json_value_extract(all_uploads_json, YtElms.ALL_UPLOADS_VIDEO_ITEM)
+		for video in videos:
+			video_id = video[YtElms.VIDEO_ID]
+			video_url = generate_video_url(video_id)
+			video_title = self.find_title(video)
+			self.all_uploads_videos[video_id] = {Keys.VIDEO_NAME: video_title, Keys.URL: video_url}
 
-    def find_title(self, d:dict) -> str :
-        # should've kept these in YtElms maybe later TODO 
-        return d['title']['runs'][0]['text']
+		# the same YtElms key name is reused 
+		need_to_scroll = len(json_value_extract(all_uploads_json, YtElms.PLAYLIST_NEED_TO_SCROLL)) > 0 
+		return need_to_scroll
+
+	def add_missing_videos_if_any(self, video_id:str, video_title:str, video_url:str) -> bool:
+		'''if the passed video wasn't already recorder returns true and adds it to record, otherwise return False'''
+		if not self.does_video_key_exist(video_id):
+			self.all_uploads_videos[video_id] = {Keys.VIDEO_NAME: video_title, Keys.URL: video_url}
+			return True
+		return False
+
+
+	def add_missing_playlists_if_any(self, playlist_id:str, playlist_title:str, playlist_url:str, gross_number_of_videos:int) -> bool:
+		'''if the passed video wasn't already recorder returns true and adds it to record, otherwise return False'''
+		if not self.does_playlist_key_exist(playlist_id):
+			self.created_playlists_metadata[playlist_id] = {Keys.PLAYLIST_NAME: playlist_title, Keys.PLAYLIST_GROSS_VIDEOS_NUMBER: gross_number_of_videos}
+			return True
+		return False
+
+	def does_playlist_key_exist(self, key):
+		if key in self.created_playlists_metadata.keys():
+			return True
+		return False
+
+	def does_video_key_exist(self, key):
+		if key in self.all_uploads_videos.keys():
+			return True
+		return False
+
+	def find_title(self, d:dict) -> str :
+		# should've kept these in YtElms maybe later TODO 
+		return d['title']['runs'][0]['text']
 
 
 

--- a/Playlist.py
+++ b/Playlist.py
@@ -5,7 +5,7 @@ from selenium.webdriver.remote.webelement import WebElement
 class Playlist():
     def __init__(self):
         # self.playlist_url = playlist_url
-        self.gross_number_of_videos = 0
+        self.gross_number_of_videos = 0 #num of videos includeding private, membersOnly and available videos
         self.num_available_videos = 0
         self.num_members_only_videos = 0
         self.playlist_id = ""

--- a/Playlist.py
+++ b/Playlist.py
@@ -1,9 +1,10 @@
-from utils import json_value_extract, Keys, get_now_date, generate_playlist_url, YtElms
+from utils import json_value_extract, Keys, get_now_date, generate_playlist_url, YtElms, generate_video_url
+from selenium.webdriver.remote.webelement import WebElement
+
 
 class Playlist():
     def __init__(self):
         # self.playlist_url = playlist_url
-        self.playlist_videos = []
         self.gross_number_of_videos = 0
         self.num_available_videos = 0
         self.num_members_only_videos = 0
@@ -76,14 +77,40 @@ class Playlist():
             return True
         return False
 
+    # test this in functional testing TODO
+    def using_html_element_is_video_members_only(self, web_element: WebElement, members_only_tag_name:str) -> bool:
+        ''' checks if the provided html tag contains 'Members only' text '''
+        for i in web_element.find_elements_by_tag_name(members_only_tag_name):
+            if "Members only" in i.text:
+                return True
+        return False
+
     def __extract_video_info_from_playlistVideoRenderer(self, video_obj:dict)->dict:
-        video_id = video_obj['videoId']
+        video_id = video_obj[YtElms.VIDEO_ID]
         video_title = video_obj['title']['runs'][0]['text']
-        length_text = video_obj['lengthText']['simpleText']
+        video_url = generate_video_url(video_id)
+        # length_text = video_obj['lengthText']['simpleText']
         # length_text = video_obj['lengthText']['accessibility']['accessibilityData']['label']
         if self.__is_video_members_only(video_obj):
-            self.members_only_videos[video_id] = {"video_title":video_title, "length":length_text}
+            self.members_only_videos[video_id] = {Keys.VIDEO_NAME: video_title, Keys.URL: video_url}
             self.num_members_only_videos +=1
         else:
-            self.available_videos[video_id] = {"video_title":video_title, "length":length_text}
+            self.available_videos[video_id] = {Keys.VIDEO_NAME: video_title, Keys.URL: video_url}
             self.num_available_videos = self.num_available_videos + 1
+    
+    def does_key_exist(self, key):
+        if key in self.available_videos.keys() or key in self.members_only_videos.keys():
+            return True
+        return False
+
+    def add_missing_videos_if_any(self, video_id:str, video_title:str, video_url:str, is_members_only:bool) -> bool:
+        '''if the passed video wasn't already recorder returns true and adds it to record, otherwise return False'''
+        if not self.does_key_exist(video_id):
+            if is_members_only:
+                self.members_only_videos[video_id] = {Keys.VIDEO_NAME: video_title, Keys.URL: video_url}
+                self.num_members_only_videos +=1
+            else:
+                self.available_videos[video_id] = {Keys.VIDEO_NAME: video_title, Keys.URL: video_url}
+                self.num_available_videos +=1
+            return True
+        return False

--- a/tests/functionality_testing/Scrapper_test.py
+++ b/tests/functionality_testing/Scrapper_test.py
@@ -56,7 +56,7 @@ class TestDownloader(unittest.TestCase):
 		assert json_dict[Keys.PLAYLIST_MEMBERS_ONLY_VIDEOS_NUMBER] == 0, f"{url} didn't correctly get all members only videos"
 
 
-	# def test_get_all_channel_playlists_info(self):
+	def test_get_all_channel_playlists_info(self):
 		playlists_only_default_view_no_scroll = "https://www.youtube.com/c/3thestorm/playlists"
 		playlist_wrong_view_with_scroll = "https://www.youtube.com/c/MegwinTVOfficial/playlists"
 		playlist_correct_view_with_scroll = "https://www.youtube.com/c/learnelectronics/playlists?view=1"
@@ -91,7 +91,7 @@ class TestDownloader(unittest.TestCase):
 		expected_no_scroll = 12
 
 		lot_of_scrolling = 'https://www.youtube.com/c/EevblogDave/videos'
-		expected_scroll_lot = 1755
+		expected_scroll_lot = 1756
 
 		url = with_scroll
 		json_dict = self.scrapper.get_all_uploads_info_for_channel(url)
@@ -108,9 +108,6 @@ class TestDownloader(unittest.TestCase):
 		num = len(list(json_dict.keys()))
 		assert num == expected_scroll_lot, f'expected {expected_scroll_lot} videos, but got {num} for {url}'
 		
-
-	def test_scrape_for_playlists(self):
-		pass
 
 if __name__ == '__main__':
 	unittest.main()

--- a/tests/functionality_testing/Scrapper_test.py
+++ b/tests/functionality_testing/Scrapper_test.py
@@ -56,7 +56,7 @@ class TestDownloader(unittest.TestCase):
 		assert json_dict[Keys.PLAYLIST_MEMBERS_ONLY_VIDEOS_NUMBER] == 0, f"{url} didn't correctly get all members only videos"
 
 
-	def test_get_all_channel_playlists_info(self):
+	# def test_get_all_channel_playlists_info(self):
 		playlists_only_default_view_no_scroll = "https://www.youtube.com/c/3thestorm/playlists"
 		playlist_wrong_view_with_scroll = "https://www.youtube.com/c/MegwinTVOfficial/playlists"
 		playlist_correct_view_with_scroll = "https://www.youtube.com/c/learnelectronics/playlists?view=1"
@@ -81,6 +81,36 @@ class TestDownloader(unittest.TestCase):
 		created_playlists = self.scrapper.get_all_channel_playlists_info(url)
 		num_playlists = len(created_playlists.keys())
 		assert num_playlists == 241,f"found {num_playlists} should have been 241, didn't get correct number of playlists for f {url}"
+
+
+	def test_get_all_uploads_info_for_channel(self):
+		with_scroll = 'https://www.youtube.com/c/3thestorm/videos'
+		expected_with_scroll = 52 
+
+		no_scroll = 'https://www.youtube.com/user/FireSymphoney/videos'
+		expected_no_scroll = 12
+
+		lot_of_scrolling = 'https://www.youtube.com/c/EevblogDave/videos'
+		expected_scroll_lot = 1755
+
+		url = with_scroll
+		json_dict = self.scrapper.get_all_uploads_info_for_channel(url)
+		num = len(list(json_dict.keys()))
+		assert num == expected_with_scroll, f'expected {expected_with_scroll} videos, but got {num} for {url}'
+
+		url = no_scroll
+		json_dict = self.scrapper.get_all_uploads_info_for_channel(url)
+		num = len(list(json_dict.keys()))
+		assert num == expected_no_scroll, f'expected {expected_no_scroll} videos, but got {num} for {url}'
+
+		url = lot_of_scrolling
+		json_dict = self.scrapper.get_all_uploads_info_for_channel(url)
+		num = len(list(json_dict.keys()))
+		assert num == expected_scroll_lot, f'expected {expected_scroll_lot} videos, but got {num} for {url}'
+		
+
+	def test_scrape_for_playlists(self):
+		pass
 
 if __name__ == '__main__':
 	unittest.main()


### PR DESCRIPTION
fixes https://github.com/brilliant-ember/YouTube-Channel-Downloader/issues/13

Note that tests do work, however, it some times fail as we get timeouts and the scrapper hangs sometimes. so every once in a while the tests fail.

Sometimes youtube gives us an infinite loading spinner when we try to download dynamic content from a playlist and  we don't detect that loading spinner (it's html class is circle and id is spinner-id as of today) and this causes us to exit the playlist prematurely and not scrape the remaining of the videos.
  
run `  python3 tests/functionality_testing/Scrapper_test.py -k "test_get_playlist_info" which passed normally, but fails when the issue happens (or a user updates their number of videos :smile:  )